### PR TITLE
feat(gke): implement private cluster [DEVOPS-126]

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ following APIs/services are enabled:
 
 * GKE
 * Cloud Resource Manager
-* Compute Service
+* Compute Engine
 * Service Networking
 
 ### Networking
@@ -67,9 +67,13 @@ the Owner role in the project. It might be possible to use the Editor role but
 currently using the Editor role returns a 403 error when IAM logWriter Role 
 permissions are being assigned. Further troubleshooting is needed.
 
-The Service Account specified in `shared_vpc_host_google_credentials` requires:
+The `shared_vpc_host_google_credentials` Service Account requires the permissions listed below.
+It is recommended to create a custom role named `Terraform Shared VPC Role` with ID 
+`terraform_shared_vpc_host_role` for convenient management:
 
-* The ability to list networks/subnetworks in `shared_vpc_host_google_project`
+* `resourcemanager.projects.get`
+* `resourcemanager.projects.getIamPolicy`
+* `resourcemanager.projects.setIamPolicy`
 
 ## Cluster Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This script/module creates a basic public GKE cluster located in a shared VPC.
 
 ## Inputs
 
-* `google_region` - region in which to create resources (defaults to `asia-southeast2`).
+* `google_region` - region in which to create resources.
 * `zones` - zones to place compute resources in (defaults to `["asia-southeast2-a", "asia-southeast2-b", "asia-southeast2-c"]`).
 * `google_project` - project in which to place compute resources (defaults to `test-api-cloud-infrastructure`).
 * `google_credentials` - service account with ability to create resources in `google_project`.
@@ -19,6 +19,16 @@ This script/module creates a basic public GKE cluster located in a shared VPC.
 
 **TODO:** Add remaining variables
 
+To run locally,export the following variables:
+
+```bash
+export TF_VAR_google_region="asia-southeast2"
+export TF_VAR_google_project=
+export TF_VAR_google_credentials=
+export TF_VAR_shared_vpc_host_google_project=
+export TF_VAR_shared_vpc_host_google_credentials= 
+```
+
 ## GCP Project Setup
 
 When preparing a GCP project for a Terraform GKE deployment, ensure the
@@ -27,6 +37,7 @@ following APIs/services are enabled:
 * GKE
 * Cloud Resource Manager
 * Compute Service
+* Service Networking
 
 ### Networking
 

--- a/gcp-gke/main.tf
+++ b/gcp-gke/main.tf
@@ -46,6 +46,7 @@ resource "random_id" "run_id" {
 # Shared VPC Permissions
 data "google_project" "service_project" {
   // Use default google provider
+  provider = google
 }
 
 data "google_project" "host_project" {

--- a/gcp-gke/main.tf
+++ b/gcp-gke/main.tf
@@ -1,4 +1,5 @@
 provider "google" {
+  alias       = "compute"
   project     = var.google_project
   region      = var.google_region
   credentials = var.google_credentials
@@ -13,7 +14,13 @@ provider "google" {
     # Required for google_client_openid_userinfo
     "https://www.googleapis.com/auth/userinfo.email",
   ]
-  version = "<= 4.0.0"
+}
+
+provider "google-beta" {
+  alias       = "compute-beta"
+  project     = var.google_project
+  region      = var.google_region
+  credentials = var.google_credentials
 }
 
 provider "google" {
@@ -25,18 +32,43 @@ provider "google" {
 
 terraform {
   required_version = ">= 0.13.1"
+
+  required_providers {
+    external = {
+      version = "~> 1.2.0"
+    }
+
+    google = {
+      version = ">= 3.0.0, <= 4.0.0"
+    }
+
+    google-beta = {
+      version = ">= 3.0.0"
+      source  = "hashicorp/google-beta"
+    }
+
+    null = {
+      version = ">=2.1.2, <= 3.0"
+      source  = "hashicorp/null"
+    }
+
+    random = {
+      version = "<= 3.0"
+    }
+
+    template = {
+      version = "<= 3.0"
+    }
+  }
 }
 
 provider "null" {
-  version = "<= 3.0"
 }
 
 provider "random" {
-  version = "<= 3.0"
 }
 
 provider "template" {
-  version = "<= 3.0"
 }
 
 resource "random_id" "run_id" {
@@ -45,8 +77,7 @@ resource "random_id" "run_id" {
 
 # Shared VPC Permissions
 data "google_project" "service_project" {
-  // Use default google provider
-  provider = google
+  provider = google.compute
 }
 
 data "google_project" "host_project" {
@@ -72,7 +103,8 @@ resource "google_project_iam_binding" "compute-network-user" {
 # GKE Cluster Config
 module "primary-cluster" {
   providers = {
-    google = google
+    google      = google.compute
+    google-beta = google-beta.compute-beta
   }
   source = "./modules/terraform-google-kubernetes-engine/modules/beta-private-cluster-update-variant"
 
@@ -89,15 +121,15 @@ module "primary-cluster" {
   horizontal_pod_autoscaling = false
   create_service_account     = true
   remove_default_node_pool   = true
-  release_channel = var.release_channel
+  release_channel            = var.release_channel
 
   // Private nodes better control public exposure, and reduce
   // the ability of nodes to reach to the Internet without
   // additional configurations.
-  enable_private_nodes = true
-  enable_shielded_nodes = true
+  enable_private_nodes        = true
+  enable_shielded_nodes       = true
   enable_intranode_visibility = true
-  add_cluster_firewall_rules = true
+  add_cluster_firewall_rules  = true
 
   # Required for GKE-installed Istio
   network_policy = true
@@ -136,16 +168,21 @@ module "primary-cluster" {
 }
 
 # We use this data provider to expose an access token for communicating with the GKE cluster.
-data "google_client_config" "default" {}
+data "google_client_config" "default" {
+  provider = google-beta.compute-beta
+}
 
 data "google_container_cluster" "current_cluster" {
+  provider = google-beta.compute-beta
+
   name     = module.primary-cluster.name
   location = module.primary-cluster.location
 }
 
+# Networking - create a NAT gateway for the cluster
 resource "google_compute_address" "cloud_nat_ip" {
   provider = google.vpc
-  name = "gke-nat"
+  name     = "gke-nat"
 }
 
 module "cloud_nat" {
@@ -159,11 +196,41 @@ module "cloud_nat" {
   router        = "gke-router"
   network       = local.network_name
   create_router = true
-  nat_ips = [google_compute_address.cloud_nat_ip.self_link]
+  nat_ips       = [google_compute_address.cloud_nat_ip.self_link]
+}
+
+# Providers for Bootstrap
+provider "helm" {
+  # Use provider with Helm 3.x support
+  version = "~> 1.3.0"
+
+  kubernetes {
+    load_config_file = false
+
+    host                   = "https://${module.primary-cluster.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(module.primary-cluster.ca_certificate)
+  }
+}
+
+provider kubernetes {
+  load_config_file = false
+
+  host                   = "https://${module.primary-cluster.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.primary-cluster.ca_certificate)
+
+  version = "~> 1.13"
 }
 
 # Bootstrap to install service mesh, logging, etc
 module bootstrap {
+  providers = {
+    helm       = helm
+    kubernetes = kubernetes
+    null       = null
+  }
+
   source = "./modules/bootstrap"
 
   google_credentials = var.google_credentials
@@ -177,4 +244,6 @@ module bootstrap {
 
   kiali_username   = var.kiali_username
   kiali_passphrase = var.kiali_passphrase
+
+  depends_on = [module.cloud_nat]
 }

--- a/gcp-gke/main.tf
+++ b/gcp-gke/main.tf
@@ -71,6 +71,9 @@ resource "google_project_iam_binding" "compute-network-user" {
 
 # GKE Cluster Config
 module "primary-cluster" {
+  providers = {
+    google = google
+  }
   source = "./modules/terraform-google-kubernetes-engine/modules/beta-private-cluster-update-variant"
 
   project_id                 = var.google_project

--- a/gcp-gke/modules/bootstrap/main.tf
+++ b/gcp-gke/modules/bootstrap/main.tf
@@ -146,6 +146,13 @@ spec:
       enabled: true
     kiali:
       enabled: true
+    prometheus:
+      enabled: true
+    prometheusOperator:
+      enabled: true
+  values:
+    prometheusOperator:
+      createPrometheusResource: false
 EOF
 EOH
   }
@@ -203,6 +210,20 @@ resource "helm_release" "jaeger" {
   set {
     name  = "rbac.clusterRole"
     value = "true"
+  }
+}
+
+# Install Prometheus Operator
+resource "helm_release" "prometheus_operator" {
+  name = "prometheus-operator"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart = "kube-prometheus-stack"
+  namespace = "prometheus"
+  create_namespace = true
+
+  set {
+    name = "serviceMonitorSelectorNilUsesHelmValues"
+    value = "false"
   }
 }
 

--- a/gcp-gke/modules/bootstrap/main.tf
+++ b/gcp-gke/modules/bootstrap/main.tf
@@ -1,32 +1,3 @@
-terraform {
-  required_version = ">=0.12.28, <0.14"
-}
-
-provider "helm" {
-  # Use provider with Helm 3.x support
-  version = "~> 1.2.4"
-
-  kubernetes {
-    load_config_file = false
-
-    host                   = var.cluster_host
-    token                  = var.cluster_token
-    cluster_ca_certificate = var.cluster_ca_certificate
-  }
-}
-
-provider "kubernetes" {
-  load_config_file = false
-
-  host                   = var.cluster_host
-  token                  = var.cluster_token
-  cluster_ca_certificate = var.cluster_ca_certificate
-}
-
-provider "null" {
-  version = " >= 1.2"
-}
-
 # setup_gcloud_cli steps
 # 1 - write GCP credentials to file
 # 2 - download gcloud CLI and extract

--- a/gcp-gke/outputs.tf
+++ b/gcp-gke/outputs.tf
@@ -29,11 +29,16 @@ output "ca_certificate" {
 }
 
 output "service_account" {
-  description = "The default service account used for running nodes."
+  description = "The default service account used for running nodes"
   value       = module.primary-cluster.service_account
 }
 
 output "cluster_name" {
   description = "The GKE cluster name that was built"
   value       = module.primary-cluster.name
+}
+
+output "cluster_nat_ips" {
+  description = "The external NAT IP address used by the GKE cluster for internet access"
+  value = google_compute_address.cloud_nat_ip.address
 }

--- a/gcp-gke/outputs.tf
+++ b/gcp-gke/outputs.tf
@@ -40,5 +40,5 @@ output "cluster_name" {
 
 output "cluster_nat_ips" {
   description = "The external NAT IP address used by the GKE cluster for internet access"
-  value = google_compute_address.cloud_nat_ip.address
+  value       = google_compute_address.cloud_nat_ip.address
 }


### PR DESCRIPTION
JIRA Issues:

https://honestbank.atlassian.net/browse/DEVOPS-126
https://honestbank.atlassian.net/browse/DEVOPS-145

This PR implements:

* GKE cluster into shared VPC
* Private GKE cluster
* Rapid Kubernetes release channel
* Node pool update variant (creates new node pools before destroying old ones)
* Cloud NAT for internet egress for Pods/Nodes