### PR TITLE
fix(*): elasticsearch resource fields, GKE node pool size

### DIFF
--- a/gcp-gke/modules/bootstrap/elastic/elastic-basic-cluster.yaml
+++ b/gcp-gke/modules/bootstrap/elastic/elastic-basic-cluster.yaml
@@ -12,6 +12,21 @@ spec:
         node.data: true
         node.ingest: true
         node.store.allow_mmap: false
+      podTemplate:
+        spec:
+          containers:
+            - name: elasticsearch
+              env:
+                - name: ES_JAVA_OPTS
+                  value: -Xms2g -Xmx2g
+              resources:
+                requests:
+                  memory: 4Gi
+                  cpu: 8
+                limits:
+                  memory: 4Gi
+  secureSettings:
+    secretName: elasticsearch-gcs-credentials
   # http:
   #   tls:
   #     certificate:

--- a/gcp-gke/modules/bootstrap/elastic/elastic-filebeat.yaml
+++ b/gcp-gke/modules/bootstrap/elastic/elastic-filebeat.yaml
@@ -12,15 +12,22 @@ spec:
       - type: container
         paths:
           - /var/log/containers/*.log
+      processors:
+      - add_host_metadata: {}
+      - add_cloud_metadata: {}
   daemonSet:
     podTemplate:
       spec:
+        automountServiceAccountToken: true
+        terminationGracePeriodSeconds: 30
         dnsPolicy: ClusterFirstWithHostNet
         hostNetwork: true
         securityContext:
           runAsUser: 0
         containers:
           - name: filebeat
+            securityContext:
+              runAsUser: 0
             volumeMounts:
               - name: varlogcontainers
                 mountPath: /var/log/containers

--- a/gcp-gke/modules/bootstrap/elastic/elastic-kibana.yaml
+++ b/gcp-gke/modules/bootstrap/elastic/elastic-kibana.yaml
@@ -8,6 +8,17 @@ spec:
   elasticsearchRef:
     name: logging
     namespace: default
+  podTemplate:
+    spec:
+      containers:
+        - name: kibana
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 0.5
+            limits:
+              memory: 2Gi
+              cpu: 2
   # http:
   #   tls:
   #     certificate:

--- a/gcp-gke/variables.tf
+++ b/gcp-gke/variables.tf
@@ -56,12 +56,12 @@ variable "release_channel" {
 
 variable "minimum_node_count" {
   default     = 1
-  description = "Minimum nodes for the node pool. This is the total nodes so for regional deployments it is the total nodes across all zones."
+  description = "Minimum nodes for the node pool per-zone.
 }
 
 variable "maximum_node_count" {
-  default     = 2
-  description = "Maximum nodes for the node pool. This is the total nodes so for regional deployments it is the total nodes across all zones."
+  default     = 1
+  description = "Maximum nodes for the node pool per-zone."
 }
 
 variable "initial_node_count" {

--- a/gcp-gke/variables.tf
+++ b/gcp-gke/variables.tf
@@ -56,7 +56,7 @@ variable "release_channel" {
 
 variable "minimum_node_count" {
   default     = 1
-  description = "Minimum nodes for the node pool per-zone.
+  description = "Minimum nodes for the node pool per-zone."
 }
 
 variable "maximum_node_count" {

--- a/remote-backend.tf
+++ b/remote-backend.tf
@@ -14,12 +14,12 @@ terraform {
 module gke {
   source = "./gcp-gke"
 
-  google_project     = var.google_project
-  google_region      = var.google_region
-  google_credentials = var.google_credentials
-  shared_vpc_host_google_project = var.shared_vpc_host_google_project
+  google_project                     = var.google_project
+  google_region                      = var.google_region
+  google_credentials                 = var.google_credentials
+  shared_vpc_host_google_project     = var.shared_vpc_host_google_project
   shared_vpc_host_google_credentials = var.shared_vpc_host_google_credentials
-  stage              = var.stage
-  cluster_purpose    = var.cluster_purpose
-  cluster_number     = var.cluster_number
+  stage                              = var.stage
+  cluster_purpose                    = var.cluster_purpose
+  cluster_number                     = var.cluster_number
 }

--- a/remote-backend.tf
+++ b/remote-backend.tf
@@ -14,12 +14,22 @@ terraform {
 module gke {
   source = "./gcp-gke"
 
-  google_project                     = var.google_project
-  google_region                      = var.google_region
-  google_credentials                 = var.google_credentials
-  shared_vpc_host_google_project     = var.shared_vpc_host_google_project
+  google_project     = var.google_project
+  google_region      = var.google_region
+  google_credentials = var.google_credentials
+  
+  shared_vpc_host_google_project = var.shared_vpc_host_google_project
   shared_vpc_host_google_credentials = var.shared_vpc_host_google_credentials
-  stage                              = var.stage
-  cluster_purpose                    = var.cluster_purpose
-  cluster_number                     = var.cluster_number
+  
+  stage              = var.stage
+  cluster_purpose    = var.cluster_purpose
+  cluster_number     = var.cluster_number
+  
+  machine_type = var.machine_type
+  minimum_node_count = var.minimum_node_count
+  maximum_node_count = var.maximum_node_count
+  initial_node_count = var.initial_node_count
+
+  kiali_username = var.kiali_username
+  kiali_passphrase = var.kiali_passphrase
 }


### PR DESCRIPTION
# Description

* Add resource constraints to Elasticsearch and Kibana manifests
* Update Filebeat manifest with info from https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-beat-configuration-examples.html
* Set GKE node pool size to min: 1 max: 2 (previously min: 1 max: 2 which caused larger clusters)