### PR TITLE
fix(istio): pin version to 1.7.5 [DEVOPS-224]

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -45,7 +45,7 @@ jobs:
               curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
               dep ensure
           fi
-      - name: Run 'go test -v -timeout 30m'
+      - name: Run 'go test -v -timeout 60m'
         run: |
           cd test
-          go test -v -timeout 30m
+          go test -v -timeout 60m

--- a/gcp-gke/modules/bootstrap/main.tf
+++ b/gcp-gke/modules/bootstrap/main.tf
@@ -52,7 +52,7 @@ resource "null_resource" "install_istio_operator" {
   provisioner "local-exec" {
     command = <<EOH
 if ! command -v kubectl; then alias kubectl=./kubectl; fi;
-curl -sL https://istio.io/downloadIstioctl | sh -
+curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.7.5 sh -
 export PATH=$PATH:$HOME/.istioctl/bin
 istioctl operator init
 kubectl label namespace default istio-injection=enabled --overwrite


### PR DESCRIPTION
Pin Istio to v1.7.5 - the latest release (v1.8) breaks the `addonComponents` field.

JIRA: https://honestbank.atlassian.net/browse/DEVOPS-224

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/41)
<!-- Reviewable:end -->
