### PR TITLE
chore(gke): update runtime and storage driver [DEVOPS-250]

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -29,7 +29,7 @@ jobs:
       - name: prepare test environment
         run: source ./test/prepare-test-environment.sh
       - name: Login to Google Cloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: "latest" # This is the default value anyways, just being explicit
           project_id: ${{ env.GOOGLE_PROJECT }}

--- a/gcp-gke/main.tf
+++ b/gcp-gke/main.tf
@@ -151,6 +151,9 @@ module "primary-cluster" {
   logging_service    = "none"
   monitoring_service = "none"
 
+  // Storage
+  gce_pd_csi_driver = true
+
   node_pools = [
     {
       name            = "pool-01"

--- a/gcp-gke/main.tf
+++ b/gcp-gke/main.tf
@@ -161,7 +161,7 @@ module "primary-cluster" {
       local_ssd_count = 0
       disk_size_gb    = 200
       disk_type       = "pd-standard"
-      image_type      = "COS"
+      image_type      = "COS_CONTAINERD"
       auto_repair     = true
       auto_upgrade    = true
       preemptible     = false

--- a/gcp-gke/main.tf
+++ b/gcp-gke/main.tf
@@ -158,6 +158,8 @@ module "primary-cluster" {
       min_count       = var.minimum_node_count
       max_count       = var.maximum_node_count
       node_count      = var.initial_node_count
+      max_surge       = var.maximum_node_count
+      max_unavailable = 1
       local_ssd_count = 0
       disk_size_gb    = 200
       disk_type       = "pd-standard"

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,7 @@ output "client_token" {
 }
 
 output "ca_certificate" {
+  sensitive = true
   value = module.gke.ca_certificate
 }
 


### PR DESCRIPTION
This PR addresses some tech debt for DEVOPS-250

* Update container runtime to use containerd
* Update storage driver to use GCE CSI driver

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/44)
<!-- Reviewable:end -->
