### PR TITLE
feat(network)!: Support network customization

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,4 @@
+output:
+  file: README.md
+  mode: inject
+formatter: "markdown"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ with ports `5775/UDP,5778/TCP,6831/UDP,6832/UDP`.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_gcp_nat"></a> [create\_gcp\_nat](#input\_create\_gcp\_nat) | Set to `true` to create an Internet NAT for ALL\_SUBNETWORKS\_ALL\_IP\_RANGES in the VPC network. | `bool` | n/a | yes |
+| <a name="input_create_gcp_router"></a> [create\_gcp\_router](#input\_create\_gcp\_router) | Set to `true` to create a router in the VPC network. | `bool` | n/a | yes |
+| <a name="input_create_public_https_firewall_rule"></a> [create\_public\_https\_firewall\_rule](#input\_create\_public\_https\_firewall\_rule) | Set to `true` to create a firewall rule allowing 0.0.0.0/0:443 on TCP to all worker nodes. | `bool` | n/a | yes |
 | <a name="input_enable_network_policy"></a> [enable\_network\_policy](#input\_enable\_network\_policy) | This value is passed to network\_policy.enabled and the negative is passed to addons\_config.network\_policy\_config.disabled. This might conflict with Workload Identity - make sure to read https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#limitations_and_requirements. | `bool` | n/a | yes |
 | <a name="input_gke_authenticator_groups_config_domain"></a> [gke\_authenticator\_groups\_config\_domain](#input\_gke\_authenticator\_groups\_config\_domain) | Domain to append to `gke-security-groups` to pass to authenticator\_groups\_config so members of that Google Group can authenticate to the cluster. Pass an empty string to disable. Domain passed here should be in the format of TLD.EXTENSION. | `string` | n/a | yes |
 | <a name="input_google_credentials"></a> [google\_credentials](#input\_google\_credentials) | Contents of a JSON keyfile of an account with write access to the project | `any` | n/a | yes |

--- a/gcp-gke/inputs.tf
+++ b/gcp-gke/inputs.tf
@@ -3,6 +3,21 @@ variable "cluster_name" {
   description = "The name to set on the GKE cluster."
 }
 
+variable "create_gcp_router" {
+  type        = bool
+  description = "Set to `true` to create a router in the VPC network."
+}
+
+variable "create_gcp_nat" {
+  type        = bool
+  description = "Set to `true` to create an Internet NAT for ALL_SUBNETWORKS_ALL_IP_RANGES in the VPC network."
+}
+
+variable "create_public_https_firewall_rule" {
+  type        = bool
+  description = "Set to `true` to create a firewall rule allowing 0.0.0.0/0:443 on TCP to all worker nodes."
+}
+
 variable "enable_network_policy" {
   type        = bool
   description = "This value is passed to network_policy.enabled and the negative is passed to addons_config.network_policy_config.disabled."

--- a/gcp-gke/main.tf
+++ b/gcp-gke/main.tf
@@ -256,31 +256,3 @@ data "google_container_cluster" "current_cluster" {
   name     = google_container_cluster.primary.name
   location = google_container_cluster.primary.location
 }
-
-resource "google_compute_router" "router" {
-  provider = google.vpc
-  name     = "${var.cluster_name}-router"
-  region   = var.google_region
-  network  = var.shared_vpc_id
-}
-
-resource "google_compute_router_nat" "nat" {
-  provider                           = google.vpc
-  name                               = "${var.cluster_name}-nat"
-  router                             = google_compute_router.router.name
-  region                             = var.google_region
-  nat_ip_allocate_option             = "AUTO_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-
-  log_config {
-    enable = true
-    filter = "ERRORS_ONLY"
-  }
-
-  lifecycle {
-    ignore_changes = [
-      drain_nat_ips,
-      nat_ips,
-    ]
-  }
-}

--- a/gcp-gke/network.tf
+++ b/gcp-gke/network.tf
@@ -12,7 +12,7 @@ data "google_container_cluster" "primary" {
 resource "google_compute_firewall" "gke_private_cluster_istio_gatekeeper_rules" { #tfsec:ignore:google-compute-no-public-ingress
   provider = google.vpc
 
-  name    = "honest-${var.cluster_name}-private-cluster-allow"
+  name    = "honest-${var.cluster_name}-allow-istio-gatekeeper"
   network = var.shared_vpc_id
 
   allow {
@@ -22,5 +22,54 @@ resource "google_compute_firewall" "gke_private_cluster_istio_gatekeeper_rules" 
 
   source_ranges = [var.master_ipv4_cidr_block]
   target_tags   = [local.gke_node_pool_tag]
+}
 
+resource "google_compute_router" "router" {
+  count = var.create_gcp_router ? 1 : 0
+
+  provider = google.vpc
+  name     = "${var.cluster_name}-router"
+  region   = var.google_region
+  network  = var.shared_vpc_id
+}
+
+resource "google_compute_router_nat" "nat" {
+  count = var.create_gcp_nat ? 1 : 0
+
+  provider                           = google.vpc
+  name                               = "${var.cluster_name}-nat"
+  router                             = google_compute_router.router[0].name
+  region                             = var.google_region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      drain_nat_ips,
+      nat_ips,
+    ]
+  }
+}
+
+
+resource "google_compute_firewall" "gke_private_cluster_public_https_firewall_rule" { #tfsec:ignore:google-compute-no-public-ingress
+  count = var.create_public_https_firewall_rule ? 1 : 0
+
+  provider = google.vpc
+
+  name    = "honest-${var.cluster_name}-allow-https"
+  network = var.shared_vpc_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = [local.gke_node_pool_tag]
 }

--- a/inputs.tf
+++ b/inputs.tf
@@ -1,3 +1,18 @@
+variable "create_gcp_router" {
+  type        = bool
+  description = "Set to `true` to create a router in the VPC network."
+}
+
+variable "create_gcp_nat" {
+  type        = bool
+  description = "Set to `true` to create an Internet NAT for ALL_SUBNETWORKS_ALL_IP_RANGES in the VPC network."
+}
+
+variable "create_public_https_firewall_rule" {
+  type        = bool
+  description = "Set to `true` to create a firewall rule allowing 0.0.0.0/0:443 on TCP to all worker nodes."
+}
+
 variable "enable_network_policy" {
   type        = bool
   description = "This value is passed to network_policy.enabled and the negative is passed to addons_config.network_policy_config.disabled. This might conflict with Workload Identity - make sure to read https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#limitations_and_requirements."

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,10 @@ module "gke" {
   min_master_version = var.min_master_version
   release_channel    = "RAPID"
 
-  enable_network_policy = var.enable_network_policy
+  create_gcp_nat                    = var.create_gcp_nat
+  create_gcp_router                 = var.create_gcp_router
+  create_public_https_firewall_rule = var.create_public_https_firewall_rule
+  enable_network_policy             = var.enable_network_policy
 
   gke_authenticator_groups_config_domain = var.gke_authenticator_groups_config_domain
   google_project                         = var.google_project

--- a/test/wrapper.auto.tfvars
+++ b/test/wrapper.auto.tfvars
@@ -1,6 +1,10 @@
 ### Use this file to override variables in the template
 ### Examples are provided below:
 
+create_gcp_router                 = true
+create_gcp_nat                    = true
+create_public_https_firewall_rule = true
+
 ### Full GCP project name
 google_project                 = "test-terraform-project-01"
 shared_vpc_host_google_project = "test-terraform-project-01"

--- a/wrapper.auto.tfvars
+++ b/wrapper.auto.tfvars
@@ -1,6 +1,10 @@
 ### Use this file to override variables in the template
 ### Examples are provided below:
 
+create_gcp_router                 = true
+create_gcp_nat                    = true
+create_public_https_firewall_rule = true
+
 ### Full GCP project name
 google_project                 = "test-terraform-project-01"
 shared_vpc_host_google_project = "test-terraform-project-01"


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

This module currently automatically creates a Cloud Router and Cloud NAT in the VPC it's created in. This prevents multiple instances of this module from being deployed since GCP VPCs only allow one Internet NAT (as it should).

This change adds build flags that control the creation of the Cloud Router, Cloud NAT, as well as an HTTPS allow-all rule (`0.0.0.0/0`) which is required for most public services to be reachable.

---

BREAKING CHANGE:

This adds required variables that allows control of various network options. This is in preparation for removal of network infrastructure from this repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/68)
<!-- Reviewable:end -->
