### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -29,7 +29,7 @@ jobs:
       - name: prepare test environment
         run: source ./test/prepare-test-environment.sh
       - name: Login to Google Cloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           version: "latest" # This is the default value anyways, just being explicit
           project_id: ${{ env.GOOGLE_PROJECT }}


### PR DESCRIPTION
### Description

setup-gcloud will be updating the branch name from master to main in a future release. Even though GitHub will establish redirects, this will break any GitHub Actions workflows that pin to master. This PR updates your GitHub Actions workflows to pin to v0, which is the recommended best practice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/72)
<!-- Reviewable:end -->
