### PR TITLE
feat: expose configuration of node pool autoscaling location policy

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -39,29 +39,3 @@ jobs:
         id: plan
         run: terraform plan -no-color
         continue-on-error: true
-      - uses: actions/github-script@0.9.0
-        if: github.event_name == 'pull_request'
-        env:
-          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Validation 🤖${{ steps.validate.outputs.stdout }}
-            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-
-            <details><summary>Show Plan</summary>
-
-            \`\`\`${process.env.PLAN}\`\`\`
-
-            </details>
-
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
-
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })

--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -58,6 +58,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_autoscaling_location_policy"></a> [autoscaling\_location\_policy](#input\_autoscaling\_location\_policy) | (Optional) Location policy specifies the algorithm used when scaling-up the node pool. \ "BALANCED" - Is a best effort policy that aims to balance the sizes of available zones. \ "ANY" - Instructs the cluster autoscaler to prioritize utilization of unused reservations, and reduce preemption risk for Spot VMs. | `string` | `"BALANCED"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name to set on the GKE cluster. | `string` | n/a | yes |
 | <a name="input_create_gcp_nat"></a> [create\_gcp\_nat](#input\_create\_gcp\_nat) | Set to `true` to create an Internet NAT for ALL\_SUBNETWORKS\_ALL\_IP\_RANGES in the VPC network. | `bool` | n/a | yes |
 | <a name="input_create_gcp_router"></a> [create\_gcp\_router](#input\_create\_gcp\_router) | Set to `true` to create a router in the VPC network. | `bool` | n/a | yes |

--- a/modules/gcp-gke/inputs.tf
+++ b/modules/gcp-gke/inputs.tf
@@ -107,3 +107,16 @@ variable "stage" {
   description = "Stage: [test, dev, prod...] used as prefix for all resources."
   default     = "test"
 }
+
+variable "autoscaling_location_policy" {
+  type        = string
+  description = <<EOF
+    (Optional) Location policy specifies the algorithm used when scaling-up the node pool. \ "BALANCED" - Is a best effort policy that aims to balance the sizes of available zones. \ "ANY" - Instructs the cluster autoscaler to prioritize utilization of unused reservations, and reduce preemption risk for Spot VMs.
+  EOF
+  default     = "BALANCED"
+
+  validation {
+    condition     = contains(["BALANCED", "ANY"], var.autoscaling_location_policy)
+    error_message = "autoscaling_location_policy must be either 'BALANCED' or 'ANY'"
+  }
+}

--- a/modules/gcp-gke/main.tf
+++ b/modules/gcp-gke/main.tf
@@ -196,8 +196,9 @@ resource "google_container_node_pool" "primary_node_pool" {
   node_count = var.node_count
 
   autoscaling {
-    max_node_count = var.maximum_node_count
-    min_node_count = var.minimum_node_count
+    max_node_count  = var.maximum_node_count
+    min_node_count  = var.minimum_node_count
+    location_policy = var.autoscaling_location_policy
   }
 
   management {

--- a/test/gke_test.go
+++ b/test/gke_test.go
@@ -231,7 +231,7 @@ func TestTerraformGcpGkeTemplate(t *testing.T) {
 				WorkingDir: gkeClusterTerraformModulePath,
 			}
 			describeClusterCmdOutput := shell.RunCommandAndGetStdOut(t, describeClusterCmd)
-			assert.Contains(t, describeClusterCmdOutput, "1.23.5-gke.1501")
+			assert.Contains(t, describeClusterCmdOutput, "1.24.3-gke.900")
 
 			gkeClusterTerratestOptions := test_structure.LoadTerraformOptions(t, workingDir)
 			planResult := terraform.InitAndPlan(t, gkeClusterTerratestOptions)

--- a/test/wrapper.auto.tfvars
+++ b/test/wrapper.auto.tfvars
@@ -27,4 +27,4 @@ enable_network_policy                        = true
 master_ipv4_cidr_block                       = "10.40.0.0/28"
 master_authorized_networks_config_cidr_block = "0.0.0.0/0"
 release_channel                              = "REGULAR"
-kubernetes_version                           = "1.23.5-gke.1501"
+kubernetes_version                           = "1.24.3-gke.900"

--- a/wrapper.auto.tfvars
+++ b/wrapper.auto.tfvars
@@ -34,4 +34,4 @@ enable_network_policy                        = true
 master_ipv4_cidr_block                       = "10.40.0.0/28"
 master_authorized_networks_config_cidr_block = "0.0.0.0/0"
 release_channel                              = "REGULAR"
-kubernetes_version                           = "1.23.5-gke.1501"
+kubernetes_version                           = "1.24.3-gke.900"


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Exposes `location_policy` property of the node pool `autoscaling` block.
* This property is currently blank, i.e. not set. However, GKE will set it to `BALANCED`. This indeed is provoking an undesirable drift in which our plan suggest we try to reset it to blank. Default value is `BALANCED`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/79)
<!-- Reviewable:end -->
