### PR TITLE
fix: avoid recreation of cluster when changing client certificate property, mitigate drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ role in the shared VPC host project.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 

--- a/modules/gcp-gke/main.tf
+++ b/modules/gcp-gke/main.tf
@@ -170,6 +170,7 @@ resource "google_container_cluster" "primary" {
     ignore_changes = [
       node_pool,
       node_config,
+      master_auth[0].client_certificate_config[0].issue_client_certificate,
     ]
   }
 

--- a/modules/gcp-gke/network.tf
+++ b/modules/gcp-gke/network.tf
@@ -12,9 +12,10 @@ data "google_container_cluster" "primary" {
 resource "google_compute_firewall" "gke_private_cluster_istio_gatekeeper_rules" { #tfsec:ignore:google-compute-no-public-ingress
   provider = google.vpc
 
-  name    = "honest-${var.cluster_name}-allow-istio-gatekeeper"
-  network = var.shared_vpc_id
-
+  name      = "honest-${var.cluster_name}-allow-istio-gatekeeper"
+  network   = var.shared_vpc_id
+  disabled  = false
+  direction = "INGRESS"
   allow {
     protocol = "tcp"
     ports    = ["15017", "8443"]
@@ -22,6 +23,14 @@ resource "google_compute_firewall" "gke_private_cluster_istio_gatekeeper_rules" 
 
   source_ranges = [var.master_ipv4_cidr_block]
   target_tags   = local.all_primary_node_pool_tags
+
+  lifecycle {
+    ignore_changes = [
+      source_service_accounts,
+      target_service_accounts,
+    ]
+  }
+
 }
 
 resource "google_compute_router" "router" {


### PR DESCRIPTION

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description
This PR addresses few issues:
* Currently we have hardcoded the value of `google_container_cluster.primary.master_auth.client_certificate_config.issue_client_certificate` to `false`. However, previous consumers of this module might have set a value of `true` to this property and updating to a newer version of this module requires destroying and recreating the cluster. This PR adds an `ignore_changes` to that property so that it becomes possible to update without having to destroy the cluster.
* There is some unecessary drift in resource `google_compute_firewall.gke_private_cluster_istio_gatekeeper_rules` caused by some properties whose values we do not set, i.e. `null` but once the resource is built in GCP these properties have a value. Example `source_service_accounts` is currently not set by this module (`null`) but GCP set as an empty list `[]` and this pops up as an undesired drift `[] -> null`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/81)
<!-- Reviewable:end -->
