### PR TITLE
fix: avoid failing plan when skipping the 'primary' node pool

### DIFF
--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -50,8 +50,8 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | [random_id.node_pool_tag](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google-beta_google_client_config.default](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/google_client_config) | data source |
 | [google-beta_google_container_cluster.current_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/google_container_cluster) | data source |
-| [google_compute_instance.primary_node_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |
-| [google_compute_instance_group.primary_node_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance_group) | data source |
+| [google_compute_instance.exemplar_node_pool_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |
+| [google_compute_instance_group.exemplar_node_pool_instance_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance_group) | data source |
 | [google_container_cluster.primary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 | [google_project.host_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_project.service_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
@@ -83,7 +83,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | <a name="input_shared_vpc_host_google_project"></a> [shared\_vpc\_host\_google\_project](#input\_shared\_vpc\_host\_google\_project) | The GCP project that hosts the VPC to place the GKE cluster in - can be an in-project VPC or a shared VPC. In the case of a shared VPC, the Service Account used to run this module must have permissions to create a Router/NAT in the VPC host project. | `any` | n/a | yes |
 | <a name="input_shared_vpc_id"></a> [shared\_vpc\_id](#input\_shared\_vpc\_id) | The id of the shared VPC. | `string` | n/a | yes |
 | <a name="input_shared_vpc_self_link"></a> [shared\_vpc\_self\_link](#input\_shared\_vpc\_self\_link) | self\_link of the shared VPC to place the GKE cluster in. | `string` | n/a | yes |
-| <a name="input_skip_create_built_in_node_pool"></a> [skip\_create\_built\_in\_node\_pool](#input\_skip\_create\_built\_in\_node\_pool) | Skip creation of the primary node pool that is created with the cluster, and instead use only the `additional_node_pools`. | `bool` | `false` | no |
+| <a name="input_skip_create_built_in_node_pool"></a> [skip\_create\_built\_in\_node\_pool](#input\_skip\_create\_built\_in\_node\_pool) | Skip creation of the primary node pool that is created with the cluster, and instead use only the `additional_node_pools`.<br>    Note: setting var.skip\_create\_built\_in\_node\_pool to true requires at least one node pool specified in var.additional\_node\_pools" | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage: [test, dev, prod...] used as prefix for all resources. | `string` | `"test"` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | self\_link of the google\_compute\_subnetwork to place the GKE cluster in. | `string` | n/a | yes |
 

--- a/modules/gcp-gke/inputs.tf
+++ b/modules/gcp-gke/inputs.tf
@@ -132,6 +132,9 @@ variable "additional_node_pools" {
 
 variable "skip_create_built_in_node_pool" {
   default     = false
-  description = "Skip creation of the primary node pool that is created with the cluster, and instead use only the `additional_node_pools`."
+  description = <<EOF
+    Skip creation of the primary node pool that is created with the cluster, and instead use only the `additional_node_pools`.
+    Note: setting var.skip_create_built_in_node_pool to true requires at least one node pool specified in var.additional_node_pools"
+   EOF
   type        = bool
 }

--- a/modules/gcp-gke/node-pool-tags.tf
+++ b/modules/gcp-gke/node-pool-tags.tf
@@ -5,14 +5,16 @@
 
 locals {
   # includes the by GCP-managed tags
-  all_primary_node_pool_tags = sort(data.google_compute_instance.primary_node_pool.tags)
+  all_primary_node_pool_tags = sort(data.google_compute_instance.exemplar_node_pool_instance.tags)
+
+  exemplar_node_pool_group_url = var.skip_create_built_in_node_pool ? module.node_pools[0].managed_instance_group_urls : google_container_node_pool.primary_node_pool[0].managed_instance_group_urls
 }
 
-data "google_compute_instance_group" "primary_node_pool" {
+data "google_compute_instance_group" "exemplar_node_pool_instance_group" {
   depends_on = [google_container_node_pool.primary_node_pool[0]]
-  self_link  = element(google_container_node_pool.primary_node_pool[0].managed_instance_group_urls, 0)
+  self_link  = element(local.exemplar_node_pool_group_url, 0)
 }
 
-data "google_compute_instance" "primary_node_pool" {
-  self_link = tolist(data.google_compute_instance_group.primary_node_pool.instances)[0]
+data "google_compute_instance" "exemplar_node_pool_instance" {
+  self_link = tolist(data.google_compute_instance_group.exemplar_node_pool_instance_group.instances)[0]
 }

--- a/test/gke_test.go
+++ b/test/gke_test.go
@@ -208,7 +208,7 @@ func TestTerraformGcpGkeTemplate(t *testing.T) {
 				WorkingDir: gkeClusterTerraformModulePath,
 			}
 			describeClusterCmdOutput := shell.RunCommandAndGetStdOut(t, describeClusterCmd)
-			assert.Contains(t, describeClusterCmdOutput, "1.24.3-gke.2100")
+			assert.Contains(t, describeClusterCmdOutput, "1.24.4-gke.800")
 
 			gkeClusterTerratestOptions := test_structure.LoadTerraformOptions(t, workingDir)
 			planResult := terraform.InitAndPlan(t, gkeClusterTerratestOptions)

--- a/test/wrapper.auto.tfvars
+++ b/test/wrapper.auto.tfvars
@@ -26,7 +26,7 @@ enable_network_policy                        = true
 master_ipv4_cidr_block                       = "10.40.0.0/28"
 master_authorized_networks_config_cidr_block = "0.0.0.0/0"
 release_channel                              = "REGULAR"
-kubernetes_version                           = "1.24.3-gke.2100"
+kubernetes_version                           = "1.24.4-gke.800"
 additional_node_pools = [
   {
     name               = "highmem",

--- a/wrapper.auto.tfvars
+++ b/wrapper.auto.tfvars
@@ -33,4 +33,4 @@ enable_network_policy                        = true
 master_ipv4_cidr_block                       = "10.40.0.0/28"
 master_authorized_networks_config_cidr_block = "0.0.0.0/0"
 release_channel                              = "REGULAR"
-kubernetes_version                           = "1.24.3-gke.2100"
+kubernetes_version                           = "1.24.4-gke.800"


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Currently it is not possible to skip building the 'primary' node pool by using the variable `skip_create_built_in_node_pool`. This is because this causes plan to fail, as in file `node-pool-tags` we assume the 'primary' node pool exists.
* This PR addresses this issue by looking into the primary node pool only if `skip_create_built_in_node_pool` is `true`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/84)
<!-- Reviewable:end -->
