### PR TITLE
fix: read node pool from list instead of from map

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ module "gke" {
   pods_ip_range_name             = var.pods_ip_range_name
   services_ip_range_name         = var.services_ip_range_name
 
+  skip_create_built_in_node_pool = true
   additional_node_pools = [
     {
       name               = "primary"

--- a/modules/gcp-gke/node-pool-tags.tf
+++ b/modules/gcp-gke/node-pool-tags.tf
@@ -7,7 +7,7 @@ locals {
   # includes the by GCP-managed tags
   all_primary_node_pool_tags = sort(data.google_compute_instance.exemplar_node_pool_instance.tags)
 
-  exemplar_node_pool_group_url = var.skip_create_built_in_node_pool ? module.node_pools[0].managed_instance_group_urls : google_container_node_pool.primary_node_pool[0].managed_instance_group_urls
+  exemplar_node_pool_group_url = var.skip_create_built_in_node_pool ? values(module.node_pools)[0].managed_instance_group_urls : google_container_node_pool.primary_node_pool[0].managed_instance_group_urls
 }
 
 data "google_compute_instance_group" "exemplar_node_pool_instance_group" {


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

In a previous PR (#84 ) I wrongly read the node pool as if it would be in a list, using square brackets syntax (`[0]`), while in reality it was in a map.
Corrected in this PR by making a list from the values of the map first.
* <!-- WRITE A SHORT DESCRIPTION OF CHANGES -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/85)
<!-- Reviewable:end -->
