### PR TITLE
refactor: use project id instad of passing providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ role in the shared VPC host project.
 | <a name="input_minimum_node_count"></a> [minimum\_node\_count](#input\_minimum\_node\_count) | Minimum nodes for the node pool. This is the total nodes so for regional deployments it is the total nodes across all zones. | `string` | n/a | yes |
 | <a name="input_pods_ip_range_cidr"></a> [pods\_ip\_range\_cidr](#input\_pods\_ip\_range\_cidr) | CIDR of the secondary IP range used for Kubernetes Pods. | `string` | n/a | yes |
 | <a name="input_pods_ip_range_name"></a> [pods\_ip\_range\_name](#input\_pods\_ip\_range\_name) | Name of the secondary IP range used for Kubernetes Pods. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id of the account where gke will be deployed. Used by provider | `string` | n/a | yes |
 | <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"RAPID"` | no |
 | <a name="input_services_ip_range_cidr"></a> [services\_ip\_range\_cidr](#input\_services\_ip\_range\_cidr) | CIDR of the secondary IP range used for Kubernetes Services. | `string` | n/a | yes |
 | <a name="input_services_ip_range_name"></a> [services\_ip\_range\_name](#input\_services\_ip\_range\_name) | Name of the secondary IP range used for Kubernetes Services. | `string` | n/a | yes |

--- a/inputs.tf
+++ b/inputs.tf
@@ -67,6 +67,11 @@ variable "minimum_node_count" {
   description = "Minimum nodes for the node pool. This is the total nodes so for regional deployments it is the total nodes across all zones."
 }
 
+variable "project_id" {
+  type        = string
+  description = "Project id of the account where gke will be deployed. Used by provider"
+}
+
 variable "pods_ip_range_cidr" {
   type        = string
   description = "CIDR of the secondary IP range used for Kubernetes Pods."

--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,6 @@ resource "random_id" "run_id" {
 }
 
 module "gke" {
-  providers = {
-    google.compute           = google
-    google.vpc               = google.vpc
-    google-beta.compute-beta = google-beta.compute-beta
-  }
-
   source = "./modules/gcp-gke"
 
   stage        = var.stage

--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -13,22 +13,15 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.9 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.0 |
-| <a name="provider_google.compute"></a> [google.compute](#provider\_google.compute) | >= 4.0 |
-| <a name="provider_google.vpc"></a> [google.vpc](#provider\_google.vpc) | >= 4.0 |
-| <a name="provider_google-beta.compute-beta"></a> [google-beta.compute-beta](#provider\_google-beta.compute-beta) | >= 4.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -41,17 +34,17 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | Name | Type |
 |------|------|
 | [google-beta_google_container_cluster.primary](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
-| [google-beta_google_container_node_pool.primary_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
 | [google_compute_firewall.gke_private_cluster_istio_gatekeeper_rules](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.gke_private_cluster_public_https_firewall_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
+| [google_container_node_pool.primary_node_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool) | resource |
 | [google_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [random_id.node_pool_tag](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [google-beta_google_client_config.default](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/google_client_config) | data source |
-| [google-beta_google_container_cluster.current_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/google_container_cluster) | data source |
+| [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_compute_instance.exemplar_node_pool_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |
 | [google_compute_instance_group.exemplar_node_pool_instance_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance_group) | data source |
+| [google_container_cluster.current_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 | [google_container_cluster.primary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 | [google_project.host_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_project.service_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |

--- a/modules/gcp-gke/modules/gcp-gke-node-pool/node-pool.tf
+++ b/modules/gcp-gke/modules/gcp-gke-node-pool/node-pool.tf
@@ -1,6 +1,4 @@
 resource "google_container_node_pool" "node_pool" {
-  provider = google-beta
-
   name     = var.name
   location = var.google_region
   version  = var.kubernetes_version

--- a/modules/gcp-gke/network.tf
+++ b/modules/gcp-gke/network.tf
@@ -10,8 +10,6 @@ data "google_container_cluster" "primary" {
 }
 
 resource "google_compute_firewall" "gke_private_cluster_istio_gatekeeper_rules" { #tfsec:ignore:google-compute-no-public-ingress
-  provider = google.vpc
-
   name      = "honest-${var.cluster_name}-allow-istio-gatekeeper"
   network   = var.shared_vpc_id
   disabled  = false
@@ -35,16 +33,14 @@ resource "google_compute_firewall" "gke_private_cluster_istio_gatekeeper_rules" 
 resource "google_compute_router" "router" {
   count = var.create_gcp_router ? 1 : 0
 
-  provider = google.vpc
-  name     = "${var.cluster_name}-router"
-  region   = var.google_region
-  network  = var.shared_vpc_id
+  name    = "${var.cluster_name}-router"
+  region  = var.google_region
+  network = var.shared_vpc_id
 }
 
 resource "google_compute_router_nat" "nat" {
   count = var.create_gcp_nat ? 1 : 0
 
-  provider                           = google.vpc
   name                               = "${var.cluster_name}-nat"
   router                             = google_compute_router.router[0].name
   region                             = var.google_region
@@ -67,8 +63,6 @@ resource "google_compute_router_nat" "nat" {
 
 resource "google_compute_firewall" "gke_private_cluster_public_https_firewall_rule" { #tfsec:ignore:google-compute-no-public-ingress
   count = var.create_public_https_firewall_rule ? 1 : 0
-
-  provider = google.vpc
 
   name    = "honest-${var.cluster_name}-allow-https"
   network = var.shared_vpc_id

--- a/modules/gcp-gke/node-pools.tf
+++ b/modules/gcp-gke/node-pools.tf
@@ -2,10 +2,6 @@ module "node_pools" {
   source   = "./modules/gcp-gke-node-pool"
   for_each = { for node_pool in var.additional_node_pools : node_pool.name => node_pool }
 
-  providers = {
-    google-beta = google-beta.compute-beta
-  }
-
   name               = each.value.name
   machine_type       = each.value.machine_type
   maximum_node_count = each.value.maximum_node_count


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [ ] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [ ] I have typed an adequate description that explains **why** I am making this change.
- [ ] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Update gke modules and submodules to use project id rather than passing providers
