### PR TITLE
feat: Allow port 9443 in firewall for K8 master->nodepool communication

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Run terratest
         run: |
           cd test
-          go test -v -timeout 60m
+          go test -v -timeout 120m
       - name: Release
         if: github.event_name == 'push'
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Set up Go (1.17)
+      - name: Set up Go (1.19)
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: gcloud-auth
         uses: google-github-actions/auth@v0
         with:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ role in the shared VPC host project.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ role in the shared VPC host project.
 | <a name="output_client_token"></a> [client\_token](#output\_client\_token) | n/a |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The GKE cluster name that was built |
 | <a name="output_cluster_project"></a> [cluster\_project](#output\_cluster\_project) | The project hosting the GKE cluster. |
-| <a name="output_gke_cluster_istio_gatekeeper_firewall_rule_self_link"></a> [gke\_cluster\_istio\_gatekeeper\_firewall\_rule\_self\_link](#output\_gke\_cluster\_istio\_gatekeeper\_firewall\_rule\_self\_link) | The tags applied to the primary node pool of the GKE cluster. |
 | <a name="output_gke_cluster_primary_node_pool_tag"></a> [gke\_cluster\_primary\_node\_pool\_tag](#output\_gke\_cluster\_primary\_node\_pool\_tag) | Tag applied to the node pool instances - used for network/firewall rules. |
 | <a name="output_kubernetes_endpoint"></a> [kubernetes\_endpoint](#output\_kubernetes\_endpoint) | n/a |
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | The default service account used for running nodes. |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ role in the shared VPC host project.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -42,6 +42,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 |------|------|
 | [google-beta_google_container_cluster.primary](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
 | [google-beta_google_container_node_pool.primary_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
+| [google_compute_firewall.gke_private_cluster_allow_9443_kyverno](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.gke_private_cluster_istio_gatekeeper_rules](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.gke_private_cluster_public_https_firewall_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |

--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -42,8 +42,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 |------|------|
 | [google-beta_google_container_cluster.primary](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
 | [google-beta_google_container_node_pool.primary_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
-| [google_compute_firewall.gke_private_cluster_allow_9443_kyverno](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
-| [google_compute_firewall.gke_private_cluster_istio_gatekeeper_rules](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.gke_private_cluster_cp_to_nodepool_comm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.gke_private_cluster_public_https_firewall_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
@@ -68,6 +67,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | <a name="input_create_gcp_router"></a> [create\_gcp\_router](#input\_create\_gcp\_router) | Set to `true` to create a router in the VPC network. | `bool` | n/a | yes |
 | <a name="input_create_public_https_firewall_rule"></a> [create\_public\_https\_firewall\_rule](#input\_create\_public\_https\_firewall\_rule) | Set to `true` to create a firewall rule allowing 0.0.0.0/0:443 on TCP to all worker nodes. | `bool` | n/a | yes |
 | <a name="input_enable_network_policy"></a> [enable\_network\_policy](#input\_enable\_network\_policy) | This value is passed to network\_policy.enabled and the negative is passed to addons\_config.network\_policy\_config.disabled. | `bool` | n/a | yes |
+| <a name="input_firewall_allow_ports_k8_cp_to_np"></a> [firewall\_allow\_ports\_k8\_cp\_to\_np](#input\_firewall\_allow\_ports\_k8\_cp\_to\_np) | List of ports to allow K8 Control plane to communicate with nodepool | `list(string)` | <pre>[<br>  "15017",<br>  "8443",<br>  "9443"<br>]</pre> | no |
 | <a name="input_gke_authenticator_groups_config_domain"></a> [gke\_authenticator\_groups\_config\_domain](#input\_gke\_authenticator\_groups\_config\_domain) | Domain to append to `gke-security-groups` to pass to authenticator\_groups\_config so members of that Google Group can authenticate to the cluster. Pass an empty string to disable. Domain passed here should be in the format of TLD.EXTENSION. | `string` | n/a | yes |
 | <a name="input_google_project"></a> [google\_project](#input\_google\_project) | The GCP project to use for this run | `any` | n/a | yes |
 | <a name="input_google_region"></a> [google\_region](#input\_google\_region) | GCP region used to create all resources in this run | `any` | n/a | yes |
@@ -99,7 +99,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The GKE cluster name that was built |
 | <a name="output_cluster_primary_node_pool_tag"></a> [cluster\_primary\_node\_pool\_tag](#output\_cluster\_primary\_node\_pool\_tag) | Tag applied to the node pool instances - used for network/firewall rules. |
 | <a name="output_cluster_project"></a> [cluster\_project](#output\_cluster\_project) | The project hosting the GKE cluster. |
-| <a name="output_istio_gatekeeper_firewall_rule_self_link"></a> [istio\_gatekeeper\_firewall\_rule\_self\_link](#output\_istio\_gatekeeper\_firewall\_rule\_self\_link) | The self\_link attribute of the firewall rule created to allow Gatekeeper and Istio to function. |
+| <a name="output_istio_gatekeeper_firewall_rule_self_link"></a> [istio\_gatekeeper\_firewall\_rule\_self\_link](#output\_istio\_gatekeeper\_firewall\_rule\_self\_link) | The self\_link attribute of the firewall rule created to allow CP to NP communication |
 | <a name="output_kubernetes_endpoint"></a> [kubernetes\_endpoint](#output\_kubernetes\_endpoint) | The kubernetes\_endpoint output of the google\_container\_cluster resource. |
 | <a name="output_node_pool_service_account_email"></a> [node\_pool\_service\_account\_email](#output\_node\_pool\_service\_account\_email) | The default service account used for running nodes |
 <!-- END_TF_DOCS -->

--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -42,7 +42,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 |------|------|
 | [google-beta_google_container_cluster.primary](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
 | [google-beta_google_container_node_pool.primary_node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
-| [google_compute_firewall.gke_private_cluster_cp_to_nodepool_comm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.gke_private_cluster_master_to_nodepool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_firewall.gke_private_cluster_public_https_firewall_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
@@ -67,7 +67,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | <a name="input_create_gcp_router"></a> [create\_gcp\_router](#input\_create\_gcp\_router) | Set to `true` to create a router in the VPC network. | `bool` | n/a | yes |
 | <a name="input_create_public_https_firewall_rule"></a> [create\_public\_https\_firewall\_rule](#input\_create\_public\_https\_firewall\_rule) | Set to `true` to create a firewall rule allowing 0.0.0.0/0:443 on TCP to all worker nodes. | `bool` | n/a | yes |
 | <a name="input_enable_network_policy"></a> [enable\_network\_policy](#input\_enable\_network\_policy) | This value is passed to network\_policy.enabled and the negative is passed to addons\_config.network\_policy\_config.disabled. | `bool` | n/a | yes |
-| <a name="input_firewall_allow_ports_k8_cp_to_np"></a> [firewall\_allow\_ports\_k8\_cp\_to\_np](#input\_firewall\_allow\_ports\_k8\_cp\_to\_np) | List of ports to allow K8 Control plane to communicate with nodepool | `list(string)` | <pre>[<br>  "15017",<br>  "8443",<br>  "9443"<br>]</pre> | no |
+| <a name="input_firewall_allow_ports_k8_cp_to_np"></a> [firewall\_allow\_ports\_k8\_cp\_to\_np](#input\_firewall\_allow\_ports\_k8\_cp\_to\_np) | List of ports to allow K8 Control plane to communicate with nodepool | `list(string)` | `[]` | no |
 | <a name="input_gke_authenticator_groups_config_domain"></a> [gke\_authenticator\_groups\_config\_domain](#input\_gke\_authenticator\_groups\_config\_domain) | Domain to append to `gke-security-groups` to pass to authenticator\_groups\_config so members of that Google Group can authenticate to the cluster. Pass an empty string to disable. Domain passed here should be in the format of TLD.EXTENSION. | `string` | n/a | yes |
 | <a name="input_google_project"></a> [google\_project](#input\_google\_project) | The GCP project to use for this run | `any` | n/a | yes |
 | <a name="input_google_region"></a> [google\_region](#input\_google\_region) | GCP region used to create all resources in this run | `any` | n/a | yes |
@@ -99,7 +99,6 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The GKE cluster name that was built |
 | <a name="output_cluster_primary_node_pool_tag"></a> [cluster\_primary\_node\_pool\_tag](#output\_cluster\_primary\_node\_pool\_tag) | Tag applied to the node pool instances - used for network/firewall rules. |
 | <a name="output_cluster_project"></a> [cluster\_project](#output\_cluster\_project) | The project hosting the GKE cluster. |
-| <a name="output_istio_gatekeeper_firewall_rule_self_link"></a> [istio\_gatekeeper\_firewall\_rule\_self\_link](#output\_istio\_gatekeeper\_firewall\_rule\_self\_link) | The self\_link attribute of the firewall rule created to allow CP to NP communication |
 | <a name="output_kubernetes_endpoint"></a> [kubernetes\_endpoint](#output\_kubernetes\_endpoint) | The kubernetes\_endpoint output of the google\_container\_cluster resource. |
 | <a name="output_node_pool_service_account_email"></a> [node\_pool\_service\_account\_email](#output\_node\_pool\_service\_account\_email) | The default service account used for running nodes |
 <!-- END_TF_DOCS -->

--- a/modules/gcp-gke/inputs.tf
+++ b/modules/gcp-gke/inputs.tf
@@ -18,6 +18,14 @@ variable "create_public_https_firewall_rule" {
   description = "Set to `true` to create a firewall rule allowing 0.0.0.0/0:443 on TCP to all worker nodes."
 }
 
+variable "firewall_allow_ports_k8_cp_to_np" {
+  type        = list(string)
+  description = "List of ports to allow K8 Control plane to communicate with nodepool"
+  default     = ["15017", "8443", "9443"]
+  # 15017 and 8443 are for Istio and Gatekeeper
+  # 9443 is for Kyverno
+}
+
 variable "enable_network_policy" {
   type        = bool
   description = "This value is passed to network_policy.enabled and the negative is passed to addons_config.network_policy_config.disabled."

--- a/modules/gcp-gke/inputs.tf
+++ b/modules/gcp-gke/inputs.tf
@@ -21,9 +21,7 @@ variable "create_public_https_firewall_rule" {
 variable "firewall_allow_ports_k8_cp_to_np" {
   type        = list(string)
   description = "List of ports to allow K8 Control plane to communicate with nodepool"
-  default     = ["15017", "8443", "9443"]
-  # 15017 and 8443 are for Istio and Gatekeeper
-  # 9443 is for Kyverno
+  default     = []
 }
 
 variable "enable_network_policy" {

--- a/modules/gcp-gke/modules/gcp-gke-node-pool/inputs.tf
+++ b/modules/gcp-gke/modules/gcp-gke-node-pool/inputs.tf
@@ -88,3 +88,13 @@ variable "zones" {
     "asia-southeast2-c",
   ]
 }
+
+variable "nodepool_ops_timeouts" {
+  type        = map(string)
+  description = "Timeout values for nodepool create/update/delete operations"
+  default = {
+    "create" : "60m",
+    "update" : "60m",
+    "delete" : "60m"
+  }
+}

--- a/modules/gcp-gke/modules/gcp-gke-node-pool/node-pool.tf
+++ b/modules/gcp-gke/modules/gcp-gke-node-pool/node-pool.tf
@@ -53,6 +53,12 @@ resource "google_container_node_pool" "node_pool" {
     tags = var.tags
   }
 
+  timeouts {
+    create = var.nodepool_ops_timeouts.create
+    update = var.nodepool_ops_timeouts.update
+    delete = var.nodepool_ops_timeouts.delete
+  }
+
   lifecycle {
     create_before_destroy = true
     ignore_changes = [

--- a/modules/gcp-gke/network.tf
+++ b/modules/gcp-gke/network.tf
@@ -9,10 +9,11 @@ data "google_container_cluster" "primary" {
   ]
 }
 
-resource "google_compute_firewall" "gke_private_cluster_cp_to_nodepool_comm" { #tfsec:ignore:google-compute-no-public-ingress
+resource "google_compute_firewall" "gke_private_cluster_master_to_nodepool" {
   provider = google.vpc
+  count    = length(var.firewall_allow_ports_k8_cp_to_np) > 0 ? 1 : 0
 
-  name      = "honest-${var.cluster_name}-allow-master-to-nodepool-comm"
+  name      = "honest-${var.cluster_name}-allow-master-to-nodepool"
   network   = var.shared_vpc_id
   disabled  = false
   direction = "INGRESS"

--- a/modules/gcp-gke/network.tf
+++ b/modules/gcp-gke/network.tf
@@ -64,7 +64,6 @@ resource "google_compute_router_nat" "nat" {
   }
 }
 
-
 resource "google_compute_firewall" "gke_private_cluster_public_https_firewall_rule" { #tfsec:ignore:google-compute-no-public-ingress
   count = var.create_public_https_firewall_rule ? 1 : 0
 
@@ -79,5 +78,20 @@ resource "google_compute_firewall" "gke_private_cluster_public_https_firewall_ru
   }
 
   source_ranges = ["0.0.0.0/0"]
+  target_tags   = [local.gke_node_pool_tag]
+}
+
+resource "google_compute_firewall" "gke_private_cluster_allow_9443_kyverno" {
+  provider = google.vpc
+
+  name    = "k8s-fw-${var.cluster_name}-allow-kyverno-comms"
+  network = var.shared_vpc_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9443"]
+  }
+
+  source_ranges = [var.master_ipv4_cidr_block]
   target_tags   = [local.gke_node_pool_tag]
 }

--- a/modules/gcp-gke/outputs.tf
+++ b/modules/gcp-gke/outputs.tf
@@ -37,8 +37,3 @@ output "cluster_all_primary_node_pool_tags" {
   description = "List of tags applied to the node pool instances. This included the managed-by-GCP tags."
   value       = local.all_primary_node_pool_tags
 }
-
-output "istio_gatekeeper_firewall_rule_self_link" {
-  description = "The self_link attribute of the firewall rule created to allow CP to NP communication"
-  value       = google_compute_firewall.gke_private_cluster_cp_to_nodepool_comm.self_link
-}

--- a/modules/gcp-gke/outputs.tf
+++ b/modules/gcp-gke/outputs.tf
@@ -39,6 +39,6 @@ output "cluster_all_primary_node_pool_tags" {
 }
 
 output "istio_gatekeeper_firewall_rule_self_link" {
-  description = "The self_link attribute of the firewall rule created to allow Gatekeeper and Istio to function."
-  value       = google_compute_firewall.gke_private_cluster_istio_gatekeeper_rules.self_link
+  description = "The self_link attribute of the firewall rule created to allow CP to NP communication"
+  value       = google_compute_firewall.gke_private_cluster_cp_to_nodepool_comm.self_link
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,11 +18,6 @@ output "cluster_project" {
   value       = module.gke.cluster_project
 }
 
-output "gke_cluster_istio_gatekeeper_firewall_rule_self_link" {
-  description = "The tags applied to the primary node pool of the GKE cluster."
-  value       = module.gke.istio_gatekeeper_firewall_rule_self_link
-}
-
 output "gke_cluster_primary_node_pool_tag" {
   description = "Tag applied to the node pool instances - used for network/firewall rules."
   value       = module.gke.cluster_primary_node_pool_tag

--- a/test/gke_test.go
+++ b/test/gke_test.go
@@ -208,7 +208,7 @@ func TestTerraformGcpGkeTemplate(t *testing.T) {
 				WorkingDir: gkeClusterTerraformModulePath,
 			}
 			describeClusterCmdOutput := shell.RunCommandAndGetStdOut(t, describeClusterCmd)
-			assert.Contains(t, describeClusterCmdOutput, "1.24.9-gke.2000")
+			assert.Contains(t, describeClusterCmdOutput, "1.24.10-gke.2300")
 
 			gkeClusterTerratestOptions := test_structure.LoadTerraformOptions(t, workingDir)
 			planResult := terraform.InitAndPlan(t, gkeClusterTerratestOptions)

--- a/test/wrapper.auto.tfvars
+++ b/test/wrapper.auto.tfvars
@@ -26,7 +26,7 @@ enable_network_policy                        = true
 master_ipv4_cidr_block                       = "10.40.0.0/28"
 master_authorized_networks_config_cidr_block = "0.0.0.0/0"
 release_channel                              = "REGULAR"
-kubernetes_version                           = "1.24.9-gke.2000"
+kubernetes_version                           = "1.24.10-gke.2300"
 additional_node_pools = [
   {
     name               = "highmem",


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

1. Allow port 9443 in firewall for K8 master nodes to talk to Kyverno clusterIP service running in nodepool
2. Refactor code to take list of ports as input var instead of hardcoded values(reduces TAT for devs)
3. Fixes tests by updating
  - golang version to 1.19
  - test timeout to 120 mins
  -  k8 version to 1.24.10-gke.2300 from deprecated version 1.24.9-*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/100)
<!-- Reviewable:end -->
