### PR TITLE
fix: use provided providers rather than depending on implicit provider

### DIFF
--- a/modules/gcp-gke/main.tf
+++ b/modules/gcp-gke/main.tf
@@ -34,6 +34,8 @@ locals {
 }
 
 resource "google_service_account" "default" {
+  provider = google.compute
+
   account_id   = "${var.cluster_name}-sa"
   display_name = "${var.cluster_name} Service Account"
 }

--- a/modules/gcp-gke/node-pool-tags.tf
+++ b/modules/gcp-gke/node-pool-tags.tf
@@ -11,10 +11,14 @@ locals {
 }
 
 data "google_compute_instance_group" "exemplar_node_pool_instance_group" {
+  provider = google.compute
+
   depends_on = [google_container_node_pool.primary_node_pool[0]]
   self_link  = element(local.exemplar_node_pool_group_url, 0)
 }
 
 data "google_compute_instance" "exemplar_node_pool_instance" {
+  provider = google.compute
+
   self_link = tolist(data.google_compute_instance_group.exemplar_node_pool_instance_group.instances)[0]
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* Some resources are relying on the default (non-aliased) Google provider being the compute project, which it is not in all cases.
* Explicitly set the project on all resources and data sources based on the past providers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gke/108)
<!-- Reviewable:end -->
