### PR TITLE
feat: add maintenance policy config feature in gcp-gke module

### DIFF
--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -24,7 +24,6 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.0 |
 | <a name="provider_google.compute"></a> [google.compute](#provider\_google.compute) | >= 4.0 |
 | <a name="provider_google.vpc"></a> [google.vpc](#provider\_google.vpc) | >= 4.0 |
 | <a name="provider_google-beta.compute-beta"></a> [google-beta.compute-beta](#provider\_google-beta.compute-beta) | >= 4.0 |
@@ -67,7 +66,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | <a name="input_create_gcp_nat"></a> [create\_gcp\_nat](#input\_create\_gcp\_nat) | Set to `true` to create an Internet NAT for ALL\_SUBNETWORKS\_ALL\_IP\_RANGES in the VPC network. | `bool` | n/a | yes |
 | <a name="input_create_gcp_router"></a> [create\_gcp\_router](#input\_create\_gcp\_router) | Set to `true` to create a router in the VPC network. | `bool` | n/a | yes |
 | <a name="input_create_public_https_firewall_rule"></a> [create\_public\_https\_firewall\_rule](#input\_create\_public\_https\_firewall\_rule) | Set to `true` to create a firewall rule allowing 0.0.0.0/0:443 on TCP to all worker nodes. | `bool` | n/a | yes |
-| <a name="input_enable_dataplane_v2"></a> [enable\_dataplane\_v2](#input\_enable\_dataplane\_v2) | enable GKE Dataplane V2 for control plane. male this valur true if you need to enable it | `bool` | `false` | no |
+| <a name="input_enable_dataplane_v2"></a> [enable\_dataplane\_v2](#input\_enable\_dataplane\_v2) | Enable GKE DataPlane V2 for control plane.Set this value true if need to enable this feature. | `bool` | `false` | no |
 | <a name="input_enable_network_policy"></a> [enable\_network\_policy](#input\_enable\_network\_policy) | This value is passed to network\_policy.enabled and the negative is passed to addons\_config.network\_policy\_config.disabled. | `bool` | n/a | yes |
 | <a name="input_gke_authenticator_groups_config_domain"></a> [gke\_authenticator\_groups\_config\_domain](#input\_gke\_authenticator\_groups\_config\_domain) | Domain to append to `gke-security-groups` to pass to authenticator\_groups\_config so members of that Google Group can authenticate to the cluster. Pass an empty string to disable. Domain passed here should be in the format of TLD.EXTENSION. | `string` | n/a | yes |
 | <a name="input_google_project"></a> [google\_project](#input\_google\_project) | The GCP project to use for this run | `any` | n/a | yes |
@@ -75,6 +74,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | <a name="input_initial_node_count"></a> [initial\_node\_count](#input\_initial\_node\_count) | Initial node count, per-zone for regional clusters. | `any` | n/a | yes |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The Kubernetes version to install on the master and node pool - must be a valid version from the specified `var.release_channel` | `string` | n/a | yes |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine types to use for the node pool. | `any` | n/a | yes |
+| <a name="input_maintenance_policy_config"></a> [maintenance\_policy\_config](#input\_maintenance\_policy\_config) | (OPTIONAL) A list of objects used to configure maintenance policy | <pre>list(object({<br>    maintenance_start_time = string<br>    maintenance_end_time   = string<br>    maintenance_recurrence = string<br>  }))</pre> | `[]` | no |
 | <a name="input_master_authorized_networks"></a> [master\_authorized\_networks](#input\_master\_authorized\_networks) | List of master authorized networks to access the control plane. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
 | <a name="input_master_ipv4_cidr_block"></a> [master\_ipv4\_cidr\_block](#input\_master\_ipv4\_cidr\_block) | The IP range to set for master nodes, passed to master\_ipv4\_cidr\_block - /28 required by Google. | `any` | n/a | yes |
 | <a name="input_maximum_node_count"></a> [maximum\_node\_count](#input\_maximum\_node\_count) | Maximum nodes for the node pool per-zone. | `any` | n/a | yes |

--- a/modules/gcp-gke/inputs.tf
+++ b/modules/gcp-gke/inputs.tf
@@ -168,3 +168,13 @@ variable "enable_dataplane_v2" {
   default     = false
   description = "Enable GKE DataPlane V2 for control plane.Set this value true if need to enable this feature."
 }
+
+variable "maintenance_policy_config" {
+  type = list(object({
+    maintenance_start_time = string
+    maintenance_end_time   = string
+    maintenance_recurrence = string
+  }))
+  description = "(OPTIONAL) A list of objects used to configure maintenance policy "
+  default     = []
+}

--- a/modules/gcp-gke/main.tf
+++ b/modules/gcp-gke/main.tf
@@ -90,6 +90,17 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "maintenance_policy" {
+    for_each = var.maintenance_policy_config != null ? var.maintenance_policy_config : []
+    content {
+      recurring_window {
+        start_time = maintenance_policy.value.maintenance_start_time
+        end_time   = maintenance_policy.value.maintenance_end_time
+        recurrence = maintenance_policy.value.maintenance_recurrence
+      }
+    }
+  }
+
   workload_identity_config {
     workload_pool = "${data.google_project.service_project.project_id}.svc.id.goog"
   }

--- a/test/wrapper.auto.tfvars
+++ b/test/wrapper.auto.tfvars
@@ -31,6 +31,13 @@ master_authorized_networks = [
     display_name = "Access from Everywhere"
   }
 ]
+maintenance_policy_config = [
+  {
+    maintenance_start_time = "2023-05-18T13:00:00Z"
+    maintenance_end_time   = "2023-05-18T17:00:00Z"
+    maintenance_recurrence = "FREQ=WEEKLY;BYDAY=MO,TH;TZID=Asia/Bangkok"
+  }
+]
 
 release_channel    = "REGULAR"
 kubernetes_version = "1.26.2-gke.1000"


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

*  Add maintenance policy config feature in gcp-gke terraform module, So that we can set maintenance  window for gke node upgrade activity.

<!-- WRITE A SHORT DESCRIPTION OF CHANGES -->
