### PR TITLE
fix: Ensure nodepool service account has minimum ACLs [DEVOP-5997]

### DIFF
--- a/modules/gcp-gke/README.md
+++ b/modules/gcp-gke/README.md
@@ -45,6 +45,7 @@ To run E2E tests, navigate to the [test folder](../test) and run `go test -v -ti
 | [google_compute_firewall.gke_private_cluster_public_https_firewall_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
+| [google_project_iam_member.node_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [random_id.node_pool_tag](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google-beta_google_client_config.default](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/data-sources/google_client_config) | data source |

--- a/modules/gcp-gke/main.tf
+++ b/modules/gcp-gke/main.tf
@@ -41,6 +41,17 @@ resource "google_service_account" "default" {
   display_name = "${var.cluster_name} Service Account"
 }
 
+# Fix a permission issue whereby the service account running the GKE node lacks
+# the requisite minimum permissions to operate in a non-degraded state.
+# https://cloud.google.com/kubernetes-engine/docs/how-to/service-accounts#default-gke-service-agent
+resource "google_project_iam_member" "node_service_account" {
+  provider = google.compute
+
+  project = var.google_project
+  role    = "roles/container.defaultNodeServiceAccount"
+  member  = google_service_account.default.member
+}
+
 #tfsec:ignore:google-gke-enforce-pod-security-policy
 #tfsec:ignore:google-gke-metadata-endpoints-disabled (legacy metadata disabled by default since 1.12 https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/container_cluster#nested_workload_identity_config)
 #tfsec:ignore:google-gke-enable-master-networks

--- a/test/wrapper.auto.tfvars
+++ b/test/wrapper.auto.tfvars
@@ -43,7 +43,7 @@ enable_l4_ilb_subsetting       = true
 deletion_protection            = false
 
 release_channel    = "RAPID"
-kubernetes_version = "1.32.0-gke.1448000"
+kubernetes_version = "1.32.1-gke.1357001"
 
 additional_node_pools = [
   {


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.
- [x] All entities that I am working with are up-to-date in Backstage; if updates are needed, I have linked the relevant PRs. [Backstage guide](https://www.notion.so/honestbank/How-to-Write-a-Backstage-Service-Catalog-Entry-a-catalog-info-yaml-file-21845ff72e404b14aed2ac989fb202cf?pvs=4)

### Description

Currently the service account used for the nodepools does not have the
minimum permissions set, so are running in a degraded manner.

https://cloud.google.com/kubernetes-engine/docs/how-to/service-accounts#default-gke-service-agent

Refs: #DEVOP-5997

Signed-off-by: Christian Witts <christian@honestbank.com>

