### PR TITLE
feat: [DEVOP-7631] upgrade Go to 1.26 in terratest modules

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.26
         id: go
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,8 +1,6 @@
 module github.com/honestbank/terraform-gcp-gke/v2
 
-go 1.22.0
-
-toolchain go1.22.6
+go 1.26
 
 require (
 	github.com/gruntwork-io/go-commons v0.17.2


### PR DESCRIPTION
## Summary
- Upgraded Go version to 1.26 in all terratest go.mod files
- Ran `go mod tidy` to update dependencies
- Updated GitHub Actions workflow `.github/workflows/terratest.yaml` go-version to 1.26

## go.mod files updated
- `test/go.mod`
- `test/modules/terraform-gcp-vpc/test/go.mod`


## Linear Issue
DEVOP-7631